### PR TITLE
simplify endpoint inputs

### DIFF
--- a/titiler/xarray/factory.py
+++ b/titiler/xarray/factory.py
@@ -75,7 +75,6 @@ def get_variable(
 
     # TODO - address this time_slice issue
     if "time" in da.dims:
-        # times = [str(x.data) for x in ds.time]
         if time_slice:
             time_as_str = time_slice.split("T")[0]
             # TODO(aimee): when do we actually need multiple slices of data?


### PR DESCRIPTION
This PR does:
- update the endpoint input
   -  replace `z` by `group` parameter in `/tilejson` endpoint
   - add `group` in `/variables` and `/info` endpoint 
   - reorder parameters 
- update variable name to make a difference between xarray.dataset and xarray.dataarray 

This will break any deployed Frontend 