### PR TITLE
add ZarrReader and rename Factory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,5 @@ repos:
       - id: mypy
         language_version: python
         exclude: tests/.*
-        # additional_dependencies:
-        # - types-simplejson
-        # - types-attrs
-        # - types-cachetools
+        additional_dependencies:
+        - types-attrs

--- a/titiler/xarray/main.py
+++ b/titiler/xarray/main.py
@@ -14,7 +14,7 @@ from titiler.core.middleware import (
     TotalTimeMiddleware,
 )
 from titiler.xarray import __version__ as titiler_version
-from titiler.xarray.factory import XarrayTilerFactory
+from titiler.xarray.factory import ZarrTilerFactory
 from titiler.xarray.settings import ApiSettings
 
 logging.getLogger("botocore.credentials").disabled = True
@@ -31,7 +31,7 @@ app = FastAPI(
 
 ###############################################################################
 # Tiles endpoints
-xarray_factory = XarrayTilerFactory()
+xarray_factory = ZarrTilerFactory()
 app.include_router(xarray_factory.router, tags=["Xarray Tiler API"])
 
 ###############################################################################

--- a/titiler/xarray/reader.py
+++ b/titiler/xarray/reader.py
@@ -1,0 +1,157 @@
+"""ZarrReader."""
+
+import contextlib
+from typing import Any, Dict, List, Optional
+
+import attr
+import fsspec
+import numpy
+import xarray
+from morecantile import TileMatrixSet
+from rasterio.crs import CRS
+from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
+from rio_tiler.io.xarray import XarrayReader
+from rio_tiler.types import BBox
+
+
+def xarray_open_dataset(
+    src_path: str,
+    group: Optional[Any] = None,
+    reference: Optional[bool] = False,
+    decode_times: Optional[bool] = True,
+) -> xarray.Dataset:
+    """Open dataset."""
+    xr_open_args: Dict[str, Any] = {
+        "engine": "zarr",
+        "decode_coords": "all",
+        "decode_times": decode_times,
+        "consolidated": True,
+    }
+    if group:
+        xr_open_args["group"] = group
+
+    if reference:
+        fs = fsspec.filesystem(
+            "reference",
+            fo=src_path,
+            remote_options={"anon": True},
+        )
+        src_path = fs.get_mapper("")
+        xr_open_args["backend_kwargs"] = {"consolidated": False}
+
+    return xarray.open_dataset(src_path, **xr_open_args)
+
+
+def get_variable(
+    ds: xarray.Dataset,
+    variable: str,
+    time_slice: Optional[str] = None,
+    drop_dim: Optional[str] = None,
+) -> xarray.DataArray:
+    """Get Xarray variable as DataArray."""
+    ds = ds.rename({"lat": "y", "lon": "x"})
+    if drop_dim:
+        dim_to_drop, dim_val = drop_dim.split("=")
+        ds = ds.sel({dim_to_drop: dim_val}).drop(dim_to_drop)
+
+    da = ds[variable]
+
+    if (da.x > 180).any():
+        # Adjust the longitude coordinates to the -180 to 180 range
+        da = da.assign_coords(x=(da.x + 180) % 360 - 180)
+
+        # Sort the dataset by the updated longitude coordinates
+        da = da.sortby(da.x)
+
+    # Make sure we have a valid CRS
+    crs = da.rio.crs or "epsg:4326"
+    da.rio.write_crs(crs, inplace=True)
+
+    # TODO - address this time_slice issue
+    if "time" in da.dims:
+        if time_slice:
+            time_as_str = time_slice.split("T")[0]
+            # TODO(aimee): when do we actually need multiple slices of data?
+            # Perhaps if aggregating for coverage?
+            # ds = ds[time_slice : time_slice + 1]
+            if da["time"].dtype == "O":
+                da["time"] = da["time"].astype("datetime64[ns]")
+            da = da.sel(
+                time=numpy.array(time_as_str, dtype=numpy.datetime64), method="nearest"
+            )
+        else:
+            da = da.isel(time=0)
+
+    return da
+
+
+@attr.s
+class ZarrReader(XarrayReader):
+    """ZarrReader: Open Zarr file and access DataArray."""
+
+    src_path: str = attr.ib()
+    variable: str = attr.ib()
+
+    # xarray.Dataset options
+    reference: bool = attr.ib(default=False)
+    decode_times: bool = attr.ib(default=False)
+    group: Optional[Any] = attr.ib(default=None)
+
+    # xarray.DataArray options
+    time_slice: Optional[str] = attr.ib(default=None)
+    drop_dim: Optional[str] = attr.ib(default=None)
+
+    tms: TileMatrixSet = attr.ib(default=WEB_MERCATOR_TMS)
+    geographic_crs: CRS = attr.ib(default=WGS84_CRS)
+
+    ds: xarray.Dataset = attr.ib(init=False)
+    input: xarray.DataArray = attr.ib(init=False)
+
+    bounds: BBox = attr.ib(init=False)
+    crs: CRS = attr.ib(init=False)
+
+    _minzoom: int = attr.ib(init=False, default=None)
+    _maxzoom: int = attr.ib(init=False, default=None)
+
+    _dims: List = attr.ib(init=False, factory=list)
+    _ctx_stack = attr.ib(init=False, factory=contextlib.ExitStack)
+
+    def __attrs_post_init__(self):
+        """Set bounds and CRS."""
+        self.ds = self._ctx_stack.enter_context(
+            xarray_open_dataset(
+                self.src_path,
+                group=self.group,
+                reference=self.reference,
+            ),
+        )
+        self.input = get_variable(
+            self.ds,
+            self.variable,
+            time_slice=self.time_slice,
+            drop_dim=self.drop_dim,
+        )
+
+        self.bounds = tuple(self.input.rio.bounds())
+        self.crs = self.input.rio.crs
+
+        self._dims = [
+            d
+            for d in self.input.dims
+            if d not in [self.input.rio.x_dim, self.input.rio.y_dim]
+        ]
+
+    @classmethod
+    def list_variables(
+        cls,
+        src_path: str,
+        group: Optional[Any] = None,
+        reference: Optional[bool] = False,
+    ) -> List[str]:
+        """List available variable in a dataset."""
+        with xarray_open_dataset(
+            src_path,
+            group=group,
+            reference=reference,
+        ) as ds:
+            return list(ds.data_vars)  # type: ignore


### PR DESCRIPTION
Simplify the Zarr Open+Read by creating a ZarrReader built on top of rio-tiler XarrayReader


```python
with ZarrReader("s3://power-analysis-ready-datastore/power_901_monthly_meteorology_utc.zarr", variable="TS") as src:
    src.tile(0, 0, 0)

ImageData(array=masked_array(
  data=[[[247.3828125, 247.4921875, 247.65625, ..., 247.171875,
          247.2421875, 247.28125],
         [247.3828125, 247.4921875, 247.65625, ..., 247.171875,
          247.2421875, 247.28125],
         [247.6640625, 247.796875, 248.0, ..., 247.359375, 247.421875,
          247.5234375],
         ...,
         [258.1875, 259.0703125, 260.4765625, ..., 255.078125,
          256.4765625, 257.3359375],
         [251.703125, 252.1015625, 252.5078125, ..., 250.2265625,
          250.890625, 251.2421875],
         [251.703125, 252.1015625, 252.5078125, ..., 250.2265625,
          250.890625, 251.2421875]]],
  mask=[[[False, False, False, ..., False, False, False],
         [False, False, False, ..., False, False, False],
         [False, False, False, ..., False, False, False],
         ...,
         [False, False, False, ..., False, False, False],
         [False, False, False, ..., False, False, False],
         [False, False, False, ..., False, False, False]]],
  fill_value=1e+20), assets=None, bounds=BoundingBox(left=-20037508.342789244, bottom=-20037508.34278919, right=20037508.34278919, top=20037508.342789244), crs=CRS.from_epsg(3857), metadata={}, band_names=[], dataset_statistics=((150.0, 350.0),), cutline_mask=None)
```