### PR TITLE
Upgrade pip

### DIFF
--- a/infrastructure/aws/lambda/Dockerfile
+++ b/infrastructure/aws/lambda/Dockerfile
@@ -15,6 +15,7 @@ COPY titiler/ titiler/
 # and becaise we NEED to remove both boto3 and botocore to save space for the package
 # we have to force using old package version that seems `almost` compatible with Lambda env botocore
 # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+RUN pip install --upgrade pip
 RUN pip install . "rio-tiler>=4.1.11" "cftime" "mangum>=0.10.0" "pandas==1.5.3" "botocore==1.29.76" "aiobotocore==2.5.0" "s3fs==2023.4.0" "fsspec==2023.4.0" "zarr==2.14.2" "xarray==0.19.0" -t /asset --no-binary pydantic
 
 # Reduce package size and remove useless files


### PR DESCRIPTION
When trying to deploy I got the following error when trying to install cramjam as a part of the lambda docker build step: `Cargo, the Rust package manager, is not installed or is not on PATH.`

<details>
  <summary>Click for full cdk deploy Cramjam Cargo Error</summary>
```
#11 17.07 Collecting cramjam<2.5,>=2.4.0
#11 17.16   Downloading cramjam-2.4.0.tar.gz (1.0 MB)
#11 17.20      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.0/1.0 MB 24.2 MB/s eta 0:00:00
#11 17.27   Installing build dependencies: started
#11 19.04   Installing build dependencies: finished with status 'done'
#11 19.04   Getting requirements to build wheel: started
#11 19.10   Getting requirements to build wheel: finished with status 'done'
#11 19.10   Preparing metadata (pyproject.toml): started
#11 19.16   Preparing metadata (pyproject.toml): finished with status 'error'
#11 19.16   error: subprocess-exited-with-error
#11 19.16   
#11 19.16   × Preparing metadata (pyproject.toml) did not run successfully.
#11 19.16   │ exit code: 1
#11 19.16   ╰─> [6 lines of output]
#11 19.16       
#11 19.16       Cargo, the Rust package manager, is not installed or is not on PATH.
#11 19.16       This package requires Rust and Cargo to compile extensions. Install it through
#11 19.16       the system's package manager or via https://rustup.rs/
#11 19.16       
#11 19.16       Checking for Rust toolchain....
#11 19.16       [end of output]
#11 19.16   
#11 19.16   note: This error originates from a subprocess, and is likely not a problem with pip.
#11 19.17 error: metadata-generation-failed
#11 19.17 
#11 19.17 × Encountered error while generating package metadata.
#11 19.17 ╰─> See above for output.
#11 19.17 
#11 19.17 note: This is an issue with the package mentioned above, not pip.
#11 19.17 hint: See above for details.
#11 19.17 
#11 19.17 [notice] A new release of pip is available: 23.0.1 -> 23.1.2
#11 19.17 [notice] To update, run: pip install --upgrade pip
#11 ERROR: executor failed running [/bin/sh -c pip install . "rio-tiler>=4.1.11" "cftime" "mangum>=0.10.0" "pandas==1.5.3" "botocore==1.29.76" "aiobotocore==2.5.0" "s3fs==2023.4.0" "fsspec==2023.4.0" "zarr==2.14.2" "xarray==0.19.0" -t /asset --no-binary pydantic]: exit code: 1
```
</details>

From searching, it appears the answer was to upgrade pip, which I did and deployment was successful.