### PR TITLE
Expose chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Tests use data generated locally by using `tests/fixtures/generate_test_*.py` sc
 To run all the tests:
 
 ```bash
-python -m pip install -e .["tests"]
+python -m pip install -e ".[tests]"
 python -m pytest --cov titiler.xarray --cov-report term-missing -s -vv
 ```
 
@@ -61,7 +61,7 @@ An example of Cloud Stack is available for AWS
     npm --prefix infrastructure/aws run cdk -- bootstrap
 
     # or to a specific region and or using AWS profile
-    AWS_DEFAULT_REGION=us-west-2 AWS_REGION=us-west-2 AWS_PROFILE=myprofile npm --prefix infrastructure/aws run cdk -- bootstrap
+    AWS_DEFAULT_REGION=us-west-2 AWS_REGION=us-west-2 AWS_PROFILE=CHANGE_ME npm --prefix infrastructure/aws run cdk -- bootstrap
     ```
 
 2. Update settings
@@ -80,7 +80,7 @@ An example of Cloud Stack is available for AWS
     STACK_STAGE=staging npm --prefix infrastructure/aws run cdk -- deploy titiler-xarray-staging
 
     # Deploy in specific region
-    AWS_DEFAULT_REGION=eu-central-1 AWS_REGION=eu-central-1 AWS_PROFILE=myprofile STACK_STAGE=staging  npm --prefix infrastructure/aws run cdk -- deploy titiler-xarray-staging
+AWS_DEFAULT_REGION=us-west-2 AWS_REGION=s-west-2 AWS_PROFILE=smce-veda STACK_STAGE=staging  npm --prefix infrastructure/aws run cdk -- deploy titiler-xarray
     ```
 
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ An example of Cloud Stack is available for AWS
     npm --prefix infrastructure/aws run cdk -- bootstrap
 
     # or to a specific region and or using AWS profile
-    AWS_DEFAULT_REGION=us-west-2 AWS_REGION=us-west-2 AWS_PROFILE=CHANGE_ME npm --prefix infrastructure/aws run cdk -- bootstrap
+    AWS_DEFAULT_REGION=us-west-2 AWS_REGION=us-west-2 AWS_PROFILE=myprofile npm --prefix infrastructure/aws run cdk -- bootstrap
     ```
 
 2. Update settings
@@ -80,7 +80,7 @@ An example of Cloud Stack is available for AWS
     STACK_STAGE=staging npm --prefix infrastructure/aws run cdk -- deploy titiler-xarray-staging
 
     # Deploy in specific region
-AWS_DEFAULT_REGION=us-west-2 AWS_REGION=s-west-2 AWS_PROFILE=smce-veda STACK_STAGE=staging  npm --prefix infrastructure/aws run cdk -- deploy titiler-xarray
+    AWS_DEFAULT_REGION=eu-central-1 AWS_REGION=eu-central-1 AWS_PROFILE=myprofile STACK_STAGE=staging npm --prefix infrastructure/aws run cdk -- deploy titiler-xarray-staging
     ```
 
 

--- a/titiler/xarray/reader.py
+++ b/titiler/xarray/reader.py
@@ -19,6 +19,7 @@ def xarray_open_dataset(
     group: Optional[Any] = None,
     reference: Optional[bool] = False,
     decode_times: Optional[bool] = True,
+    chunks: Optional[Dict[str, int]] = {},
 ) -> xarray.Dataset:
     """Open dataset."""
     xr_open_args: Dict[str, Any] = {
@@ -26,6 +27,8 @@ def xarray_open_dataset(
         "decode_coords": "all",
         "decode_times": decode_times,
         "consolidated": True,
+        # chunks={} loads the dataset with dask using engine preferred chunks if exposed by the backend
+        "chunks": chunks
     }
     if group:
         xr_open_args["group"] = group

--- a/titiler/xarray/reader.py
+++ b/titiler/xarray/reader.py
@@ -22,6 +22,8 @@ def xarray_open_dataset(
     chunks: Optional[Dict[str, int]] = None,
 ) -> xarray.Dataset:
     """Open dataset."""
+    if chunks is None:
+        chunks = {}
     xr_open_args: Dict[str, Any] = {
         "engine": "zarr",
         "decode_coords": "all",

--- a/titiler/xarray/reader.py
+++ b/titiler/xarray/reader.py
@@ -19,7 +19,7 @@ def xarray_open_dataset(
     group: Optional[Any] = None,
     reference: Optional[bool] = False,
     decode_times: Optional[bool] = True,
-    chunks: Optional[Dict[str, int]] = {},
+    chunks: Optional[Dict[str, int]] = None,
 ) -> xarray.Dataset:
     """Open dataset."""
     xr_open_args: Dict[str, Any] = {
@@ -28,7 +28,7 @@ def xarray_open_dataset(
         "decode_times": decode_times,
         "consolidated": True,
         # chunks={} loads the dataset with dask using engine preferred chunks if exposed by the backend
-        "chunks": chunks
+        "chunks": chunks,
     }
     if group:
         xr_open_args["group"] = group


### PR DESCRIPTION
Exposing the chunks of the underlying dataset is useful when understanding performance. The titiler-xarray backend doesn't use these chunks explicitly but implicitly the chunking impacts how many requests are made to the datastore.

Need to look into why tests are failing with `ValueError: unrecognized chunk manager dask - must be one of: []`