### PR TITLE
Add server timing middleware

### DIFF
--- a/infrastructure/aws/requirements-cdk.txt
+++ b/infrastructure/aws/requirements-cdk.txt
@@ -3,5 +3,5 @@ aws_cdk-aws_apigatewayv2_alpha==2.76.0a0
 aws_cdk-aws_apigatewayv2_integrations_alpha==2.76.0a0
 constructs>=10.0.0
 
-pydantic
+pydantic~=1.0
 python-dotenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "aiohttp",
     "titiler.core>=0.11.7,<0.12",
     "starlette-cramjam>=0.3,<0.4",
-    "python-dotenv"
+    "python-dotenv",
+    "asgi-server-timing-middleware@git+https://github.com/sm-Fifteen/asgi-server-timing-middleware",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "titiler.core>=0.11.7,<0.12",
     "starlette-cramjam>=0.3,<0.4",
     "python-dotenv",
-    "asgi-server-timing-middleware@git+https://github.com/sm-Fifteen/asgi-server-timing-middleware",
 ]
 
 [project.optional-dependencies]
@@ -44,9 +43,16 @@ test = [
     "pytest-cov",
     "pytest-asyncio",
     "httpx",
+    "yappi",
 ]
 dev = [
     "pre-commit"
+]
+debug = [
+    "yappi"
+]
+server = [
+    "uvicorn"
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,10 @@ from fastapi.testclient import TestClient
 
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
     """App fixture."""
+    monkeypatch.setenv("TITILER_XARRAY_DEBUG", "TRUE")
+
     from titiler.xarray.main import app
 
     with TestClient(app) as client:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -14,6 +14,11 @@ def test_get_variables_reference(app):
     )
     assert response.status_code == 200
     assert response.json() == ["value"]
+    assert response.headers["server-timing"]
+    timings = response.headers["server-timing"].split(",")
+    assert len(timings) == 2
+    assert timings[0].startswith("total;dur=")
+    assert timings[1].lstrip().startswith("1-xarray-open_dataset;dur=")
 
 
 def test_get_variables(app):
@@ -88,6 +93,11 @@ def test_get_tile_reference(app):
     )
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "image/png"
+    assert response.headers["server-timing"]
+    timings = response.headers["server-timing"].split(",")
+    assert len(timings) == 3
+    assert timings[1].lstrip().startswith("1-xarray-open_dataset;dur=")
+    assert timings[2].lstrip().startswith("2-rioxarray-reproject;dur=")
 
 
 def test_get_tile(app):

--- a/titiler/xarray/main.py
+++ b/titiler/xarray/main.py
@@ -2,10 +2,13 @@
 
 import logging
 
+# For ServerTimingMiddleware
+import rioxarray
+import xarray
+from asgi_server_timing import ServerTimingMiddleware
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 from starlette_cramjam.middleware import CompressionMiddleware
-from asgi_server_timing import ServerTimingMiddleware
 
 from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from titiler.core.factory import AlgorithmFactory, TMSFactory
@@ -17,10 +20,6 @@ from titiler.core.middleware import (
 from titiler.xarray import __version__ as titiler_version
 from titiler.xarray.factory import ZarrTilerFactory
 from titiler.xarray.settings import ApiSettings
-
-# For ServerTimingMiddleware
-import rioxarray
-import xarray
 
 logging.getLogger("botocore.credentials").disabled = True
 logging.getLogger("botocore.utils").disabled = True
@@ -83,10 +82,15 @@ if api_settings.debug:
     app.add_middleware(LoggerMiddleware, headers=True, querystrings=True)
     app.add_middleware(TotalTimeMiddleware)
 
-app.add_middleware(ServerTimingMiddleware, calls_to_track={
-    "1-xarray-open_dataset": (xarray.open_dataset,),
-    "2-rioxarray-reproject": (rioxarray.raster_array.RasterArray.reproject,),
-})
+app.add_middleware(
+    ServerTimingMiddleware,
+    calls_to_track={
+        "1-xarray-open_dataset": (xarray.open_dataset,),
+        "2-rioxarray-reproject": (rioxarray.raster_array.RasterArray.reproject,),
+    },
+)
+
+
 @app.get(
     "/healthz",
     description="Health Check.",

--- a/titiler/xarray/main.py
+++ b/titiler/xarray/main.py
@@ -2,10 +2,8 @@
 
 import logging
 
-# For ServerTimingMiddleware
 import rioxarray
 import xarray
-from asgi_server_timing import ServerTimingMiddleware
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 from starlette_cramjam.middleware import CompressionMiddleware
@@ -19,6 +17,7 @@ from titiler.core.middleware import (
 )
 from titiler.xarray import __version__ as titiler_version
 from titiler.xarray.factory import ZarrTilerFactory
+from titiler.xarray.middleware import ServerTimingMiddleware
 from titiler.xarray.settings import ApiSettings
 
 logging.getLogger("botocore.credentials").disabled = True
@@ -81,14 +80,13 @@ app.add_middleware(
 if api_settings.debug:
     app.add_middleware(LoggerMiddleware, headers=True, querystrings=True)
     app.add_middleware(TotalTimeMiddleware)
-
-app.add_middleware(
-    ServerTimingMiddleware,
-    calls_to_track={
-        "1-xarray-open_dataset": (xarray.open_dataset,),
-        "2-rioxarray-reproject": (rioxarray.raster_array.RasterArray.reproject,),
-    },
-)
+    app.add_middleware(
+        ServerTimingMiddleware,
+        calls_to_track={
+            "1-xarray-open_dataset": (xarray.open_dataset,),
+            "2-rioxarray-reproject": (rioxarray.raster_array.RasterArray.reproject,),
+        },
+    )
 
 
 @app.get(

--- a/titiler/xarray/main.py
+++ b/titiler/xarray/main.py
@@ -5,6 +5,7 @@ import logging
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 from starlette_cramjam.middleware import CompressionMiddleware
+from asgi_server_timing import ServerTimingMiddleware
 
 from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from titiler.core.factory import AlgorithmFactory, TMSFactory
@@ -16,6 +17,10 @@ from titiler.core.middleware import (
 from titiler.xarray import __version__ as titiler_version
 from titiler.xarray.factory import ZarrTilerFactory
 from titiler.xarray.settings import ApiSettings
+
+# For ServerTimingMiddleware
+import rioxarray
+import xarray
 
 logging.getLogger("botocore.credentials").disabled = True
 logging.getLogger("botocore.utils").disabled = True
@@ -78,7 +83,10 @@ if api_settings.debug:
     app.add_middleware(LoggerMiddleware, headers=True, querystrings=True)
     app.add_middleware(TotalTimeMiddleware)
 
-
+app.add_middleware(ServerTimingMiddleware, calls_to_track={
+    "1-xarray-open_dataset": (xarray.open_dataset,),
+    "2-rioxarray-reproject": (rioxarray.raster_array.RasterArray.reproject,),
+})
 @app.get(
     "/healthz",
     description="Health Check.",

--- a/titiler/xarray/middleware.py
+++ b/titiler/xarray/middleware.py
@@ -1,0 +1,153 @@
+"""middleware
+
+code originally from https://github.com/sm-Fifteen/asgi-server-timing-middleware by @https://github.com/sm-Fifteen
+
+License: Creative Commons Zero v1.0 Universal
+The Creative Commons CC0 Public Domain Dedication waives copyright interest in a work you've created
+and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure
+your work has the widest reach.
+As with the Unlicense and typical software licenses, CC0 disclaims warranties. CC0 is very similar to the Unlicense.
+
+"""
+
+import inspect
+import re
+from contextvars import ContextVar
+from typing import Callable, Dict, Tuple
+
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+try:
+    import yappi
+    from yappi import YFuncStats
+
+except ImportError:  # pragma: nocover
+    yappi = None  # type: ignore
+    YFuncStats = None
+
+
+_yappi_ctx_tag: ContextVar[int] = ContextVar("_yappi_ctx_tag", default=-1)
+
+
+def _get_context_tag():
+    return _yappi_ctx_tag.get()
+
+
+class ServerTimingMiddleware:
+    """Timing middleware for ASGI HTTP applications
+
+    The resulting profiler data will be returned through the standard
+    `Server-Timing` header for all requests.
+
+    .. _Server-Timing sepcification:
+    https://w3c.github.io/server-timing/#the-server-timing-header-field
+
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        calls_to_track: Dict[str, Tuple[Callable]],
+        max_profiler_mem: int = 50_000_000,
+    ) -> None:
+        """Init the middleware
+
+        Args:
+            app (ASGI v3 callable): An ASGI application
+
+            calls_to_track (Dict[str,Tuple[Callable]]): A dict of functions
+                keyed by desired output metric name.
+
+                Metric names must consist of a single rfc7230 token
+
+            max_profiler_mem (int): Memory threshold (in bytes) at which yappi's
+                profiler memory gets cleared.
+
+        """
+        assert (
+            yappi is not None
+        ), "yappi must be installed to use ServerTimingMiddleware"
+
+        for metric_name, profiled_functions in calls_to_track.items():
+            if len(metric_name) == 0:
+                raise ValueError("A Server-Timing metric name cannot be empty")
+
+            # https://httpwg.org/specs/rfc7230.html#rule.token.separators
+            # USASCII (7 bits), only visible characters (no non-printables or space), no double-quote or delimiter
+            if (
+                not metric_name.isascii()
+                or not metric_name.isprintable()
+                or re.search(r'[ "(),/:;<=>?@\[\\\]{}]', metric_name) is not None
+            ):
+                raise ValueError(
+                    '"{}" contains an invalid character for a Server-Timing metric name'.format(
+                        metric_name
+                    )
+                )
+
+            if not all(inspect.isfunction(profiled) for profiled in profiled_functions):
+                raise TypeError(
+                    'One of the targeted functions for key "{}" is not a function'.format(
+                        metric_name
+                    )
+                )
+
+        self.app = app
+        self.calls_to_track = {
+            name: list(tracked_funcs) for name, tracked_funcs in calls_to_track.items()
+        }
+        self.max_profiler_mem = max_profiler_mem
+
+        yappi.set_tag_callback(_get_context_tag)
+        yappi.set_clock_type("wall")
+
+        yappi.start()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        """Handle call."""
+
+        ctx_tag = id(scope)
+        _yappi_ctx_tag.set(ctx_tag)
+
+        async def send_wrapper(message: Message):
+            """Send Message."""
+            if message["type"] == "http.response.start":
+                response_headers = MutableHeaders(scope=message)
+
+                tracked_stats: Dict[str, YFuncStats] = {
+                    name: yappi.get_func_stats(
+                        filter={"tag": ctx_tag},
+                        filter_callback=lambda x, f=tracked_funcs: yappi.func_matches(
+                            x, f
+                        ),
+                    )
+                    for name, tracked_funcs in self.calls_to_track.items()
+                }
+
+                # NOTE (sm15): Might need to be altered to account for various edge-cases
+                timing_ms = {
+                    name: sum(x.ttot for x in stats) * 1000
+                    for name, stats in tracked_stats.items()
+                    if not stats.empty()
+                }
+
+                server_timing = ",".join(
+                    [
+                        f"{name};dur={duration_ms:.3f}"
+                        for name, duration_ms in timing_ms.items()
+                    ]
+                )
+
+                if server_timing:
+                    timings = response_headers.get("Server-Timing")
+                    response_headers["Server-Timing"] = (
+                        f"{timings}, {server_timing}" if timings else server_timing
+                    )
+
+                if yappi.get_mem_usage() >= self.max_profiler_mem:
+                    yappi.clear_stats()
+
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)


### PR DESCRIPTION
Adds timing middle ware and 2 timings for xarray.open_dataset and rioxarray.RasterArray.reproject. More may be added in the future, especially if it's apparent significant time is spent outside of the 2.