### PR TITLE
remove morecantile deprecated method and set upper limit for starlette

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "pydantic-settings~=2.0",
     "pandas==1.5.3",
     "redis",
+    # remove this once we swith to titiler>=0.16
+    "starlette<0.28",
 ]
 
 [project.optional-dependencies]

--- a/titiler/xarray/factory.py
+++ b/titiler/xarray/factory.py
@@ -538,7 +538,7 @@ class ZarrTilerFactory(BaseTilerFactory):
                         "request": request,
                         "tilejson_endpoint": tilejson_url,
                         "tms": tms,
-                        "resolutions": [tms._resolution(matrix) for matrix in tms],
+                        "resolutions": [matrix.cellSize for matrix in tms],
                     },
                     media_type="text/html",
                 )


### PR DESCRIPTION
This PR does:
- replace deprecated morecantile method (`_resolution()`)
- update starlette requirement to avoid breaking change (https://github.com/developmentseed/titiler/issues/743)