### PR TITLE
Pin Numpy<2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tests use data generated locally by using `tests/fixtures/generate_test_*.py` sc
 To run all the tests:
 
 ```bash
-python -m pip install -e ".[tests]"
+python -m pip install -e ".[test]"
 python -m pytest --cov titiler.xarray --cov-report term-missing -s -vv
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dynamic = ["version"]
 dependencies = [
     "cftime",
     "h5netcdf",
+    "numpy<2.0.0",
     "xarray",
     "rioxarray",
     "zarr",


### PR DESCRIPTION
This PR temporarily pins NumPy to resolve the failing tests reported in #59.