### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "numpy<2.0.0",
     "xarray",
     "rioxarray",
-    "zarr",
+    "zarr>=2,<3",
     "fakeredis",
     "fsspec",
     "s3fs",


### PR DESCRIPTION
Pin Zarr to version 2

Note: I haven't tested this locally, but perhaps we don't need to if tests pass?