### PR TITLE
Update project URLs to point to titiler-multidim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,9 @@ deployment = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/developmentseed/titiler-xarray"
-Issues = "https://github.com/developmentseed/titiler-xarray/issues"
-Source = "https://github.com/developmentseed/titiler-xarray"
+Homepage = "https://github.com/developmentseed/titiler-multidim"
+Issues = "https://github.com/developmentseed/titiler-multidim/issues"
+Source = "https://github.com/developmentseed/titiler-multidim"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Found a typo in the homepage/issue URLs

## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
