### PR TITLE
feat: upgrade to titiler 2.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,4 @@
 - Standard CI runs automatically on each push.
 - To run the CDK synth check, add the `run-cdk-checks` label to this PR.
 - If you push more commits after that run completes, remove and re-add the label to run it again.
-- To trigger a dev deployment, add the `deploy-dev` label.
+- To trigger a dev deployment, add the `deploy-dev` label. It smoke-tests tiles from the native MUR, virtual MUR, and virtual NLDAS Icechunk stores after deployment.

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -68,3 +68,8 @@ jobs:
         with:
           dir: "./infrastructure/aws"
           env_aws_secret_name: ""
+
+      - name: Smoke-test deployed Icechunk tiles
+        run: |
+          API_URL="$(jq -er 'to_entries[] | select(.value.Endpoint) | .value.Endpoint' "$HOME/cdk-outputs.json")"
+          uv run python scripts/test_deployment.py --api-url "$API_URL"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ uv run uvicorn titiler.multidim.main:app --reload
 To access the docs, visit <http://127.0.0.1:8000/api.html>.
 ![](https://github.com/developmentseed/titiler-multidim/assets/10407788/4368546b-5b60-4cd5-86be-fdd959374b17)
 
+## TiTiler 2 migration
+
+TiTiler 2 is a breaking API upgrade:
+
+- Use `tilesize` (pixels) instead of `tile_scale`; TileJSON defaults to `tilesize=512`, while the map viewer defaults to `tilesize=256`.
+- Tile URLs no longer include an `@{scale}x` suffix.
+- Set a selector method on the selector itself, for example `sel=time=nearest::2020-01-06`, instead of using `sel_method`.
+- TileJSON now includes additional raster metadata fields.
+
 ## Development
 
 Tests use data generated locally by using `tests/fixtures/generate_test_*.py` scripts.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,16 @@ uv run pytest tests/test_app.py::test_get_info
 ## VEDA Deployment
 
 * **Production deployments** are handled in the [NASA-IMPACT/veda-deploy](https://github.com/NASA-IMPACT/veda-deploy) repository.
-* **Test/dev stack deployments** can be triggered by applying the `deploy-dev` label to a pull request in this repository.
+* **Test/dev stack deployments** can be triggered by applying the `deploy-dev` label to a pull request in this repository. Each deployment requests a tile from the public native MUR, virtual MUR, and virtual NLDAS Icechunk stores.
 * **CDK synth checks** can be triggered by applying the `run-cdk-checks` label to a pull request in this repository. This check only runs when the label is added, so if new commits are pushed later the label must be removed and added again.
+
+To run the same deployment smoke test manually:
+
+```bash
+uv run python scripts/test_deployment.py --api-url https://your-api.execute-api.us-west-2.amazonaws.com
+```
+
+The RASI historical Icechunk store is intentionally excluded because its source data are corrupted.
 
 ## New Deployments
 
@@ -68,7 +76,7 @@ The following steps detail how to to setup and deploy the CDK stack from your lo
 
     ```bash
     # Download titiler repo
-    git clone https://github.com/developmentseed/titiler-xarray.git
+    git clone https://github.com/developmentseed/titiler-multidim.git
 
     # Install with the deployment dependencies
     uv sync --group deployment

--- a/infrastructure/aws/lambda/Dockerfile
+++ b/infrastructure/aws/lambda/Dockerfile
@@ -193,7 +193,7 @@ done
 find . -type d -name '__pycache__' -print0 | xargs -0 rm -rf
 find . -type f -name '*.py'        -print0 | xargs -0 rm -f
 find . -type d -name 'tests'       -print0 | xargs -0 rm -rf
-rm -rdf numpy/doc/ bin geos_license Misc boto3* botocore*
+rm -rdf numpy/doc/ bin geos_license Misc 
 find . -type f -name '*.so*' -exec strip --strip-unneeded {} \;
 EOF
 

--- a/infrastructure/aws/lambda/handler.py
+++ b/infrastructure/aws/lambda/handler.py
@@ -167,7 +167,10 @@ if "AWS_EXECUTION_ENV" in os.environ and api_settings.telemetry_enabled:
 
         def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
             """Add SigV4 Authorization header to the request."""
-            credentials = BotocoreSession().get_credentials().get_frozen_credentials()
+            credentials = BotocoreSession().get_credentials()
+            if credentials is None:
+                raise RuntimeError("AWS credentials are required to sign OTLP requests")
+            frozen_credentials = credentials.get_frozen_credentials()
             parsed = urlparse(r.url)
             body = r.body if r.body is not None else b""
             body_bytes = body if isinstance(body, bytes) else body.encode("utf-8")
@@ -189,9 +192,9 @@ if "AWS_EXECUTION_ENV" in os.environ and api_settings.telemetry_enabled:
                 data=body_bytes,
                 headers=sign_headers,
             )
-            botocore.auth.SigV4Auth(credentials, self._service, self._region).add_auth(
-                aws_req
-            )
+            botocore.auth.SigV4Auth(
+                frozen_credentials, self._service, self._region
+            ).add_auth(aws_req)
             for key in (
                 "Authorization",
                 "X-Amz-Date",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "titiler-core>=0.25.0,<0.26",
-    "titiler-xarray>=0.25.0,<0.26",
+    "titiler-core>=2.2.1,<3.0",
+    "titiler-xarray>=2.2.1,<3.0",
     "aiobotocore>=2.24.0",
     "aiohttp",
     "boto3>=1.39.0",

--- a/scripts/test_deployment.py
+++ b/scripts/test_deployment.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Smoke-test public Icechunk datasets against a deployed API."""
+
+import argparse
+import logging
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+TEST_CASES = (
+    (
+        "native MUR Icechunk",
+        "5/8/13",
+        {
+            "url": "s3://nasa-eodc-public/icechunk/MUR-JPL-L4-GLOB-v4.1-native-v0/",
+            "variable": "analysed_sst",
+            "colormap_name": "thermal",
+            "rescale": "273,325",
+            "decode_times": "true",
+        },
+    ),
+    (
+        "virtual MUR Icechunk",
+        "5/8/13",
+        {
+            "url": "s3://nasa-eodc-public/icechunk/MUR-JPL-L4-GLOB-v4.1-virtual-v2-p2",
+            "variable": "analysed_sst",
+            "colormap_name": "thermal",
+            "rescale": "273,325",
+            "sel": "time=2024-08-01T09:00:00.000000000",
+            "decode_times": "true",
+        },
+    ),
+    (
+        "virtual NLDAS Icechunk",
+        "5/8/13",
+        {
+            "url": "s3://nasa-waterinsight/virtual-zarr-store/NLDAS-3-icechunk/",
+            "variable": "Tair",
+            "colormap_name": "thermal",
+            "rescale": "260,325",
+            "sel": "time=2001-01-02T00:00:00.000000000",
+        },
+    ),
+    (
+        "MUR SST zarr",
+        "5/8/13",
+        {
+            "url": "s3://mur-sst/zarr-v1",
+            "variable": "analysed_sst",
+            "colormap_name": "thermal",
+            "rescale": "273,325",
+            "sel": "time=nearest::2002-07-05T00:00:00Z",
+            "decode_times": "true",
+        },
+    ),
+)
+
+
+def main() -> int:
+    """Request a tile for each deployed public Icechunk dataset."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-url", required=True, help="Deployed API endpoint")
+    args = parser.parse_args()
+
+    failures = []
+    for name, tile, params in TEST_CASES:
+        url = f"{args.api_url.rstrip('/')}/tiles/WebMercatorQuad/{tile}.png?{urlencode(params)}"
+        logging.info("Requesting %s", name)
+        try:
+            with urlopen(url, timeout=300) as response:
+                if (
+                    response.status != 200
+                    or response.headers.get_content_type() != "image/png"
+                    or response.read(8) != b"\x89PNG\r\n\x1a\n"
+                ):
+                    failures.append(f"{name}: unexpected response from {url}")
+        except (HTTPError, URLError, TimeoutError) as error:
+            failures.append(f"{name}: {error}")
+
+    for failure in failures:
+        logging.error(failure)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    raise SystemExit(main())

--- a/src/titiler/multidim/factory.py
+++ b/src/titiler/multidim/factory.py
@@ -8,7 +8,7 @@ import numpy as np
 from attrs import define
 from fastapi import Depends, Query
 from starlette.requests import Request
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, RedirectResponse
 from starlette.templating import Jinja2Templates
 from typing_extensions import Annotated
 
@@ -86,9 +86,17 @@ class XarrayTilerFactory(BaseTilerFactory):
                 return hist_dict
 
     def map_viewer(self) -> None:
-        """Register /map endpoints"""
+        """Register /map.html endpoint and redirect legacy /map URLs."""
 
-        @self.router.get("/{tileMatrixSetId}/map", response_class=HTMLResponse)
+        @self.router.get("/{tileMatrixSetId}/map", include_in_schema=False)
+        def map_redirect(request: Request, tileMatrixSetId: str):
+            """Redirect legacy map URLs."""
+            url = f"{request.url.path}.html"
+            if request.url.query:
+                url += f"?{request.url.query}"
+            return RedirectResponse(url)
+
+        @self.router.get("/{tileMatrixSetId}/map.html", response_class=HTMLResponse)
         def map_viewer(
             request: Request,
             tileMatrixSetId: Annotated[  # type: ignore

--- a/src/titiler/multidim/factory.py
+++ b/src/titiler/multidim/factory.py
@@ -163,6 +163,24 @@ class XarrayTilerFactory(BaseTilerFactory):
                     qs.append(("tilesize", tilesize))
                 tilejson_url += f"?{urlencode(qs)}"
 
+                point_url = self.url_for(request, "point", lon="{lon}", lat="{lat}")
+                point_qs = [
+                    (key, value)
+                    for key, value in request.query_params._list
+                    if key.lower()
+                    not in {
+                        "tilesize",
+                        "tile_format",
+                        "minzoom",
+                        "maxzoom",
+                        "buffer",
+                        "padding",
+                        "colormap",
+                        "colormap_name",
+                    }
+                ]
+                point_url += f"?{urlencode(point_qs)}"
+
                 tms = self.supported_tms.get(tileMatrixSetId)
                 return titiler_templates.TemplateResponse(
                     request,
@@ -170,6 +188,7 @@ class XarrayTilerFactory(BaseTilerFactory):
                     context={
                         "request": request,
                         "tilejson_endpoint": tilejson_url,
+                        "point_endpoint": point_url,
                         "tms": tms,
                         "resolutions": [matrix.cellSize for matrix in tms],
                     },

--- a/src/titiler/multidim/factory.py
+++ b/src/titiler/multidim/factory.py
@@ -114,16 +114,9 @@ class XarrayTilerFactory(BaseTilerFactory):
                 ),
             ] = True,
             sel: Annotated[
-                Optional[str],
+                Optional[List[str]],
                 Query(
-                    description="Xarray Indexing using dimension names `{dimension}={value}`.",
-                ),
-            ] = None,
-            method: Annotated[
-                Optional[Literal["nearest", "pad", "ffill", "backfill", "bfill"]],
-                Query(
-                    alias="sel_method",
-                    description="Xarray indexing method to use for inexact matches.",
+                    description="Xarray Indexing using `{dimension}={value}` or `{dimension}={method}::{value}`.",
                 ),
             ] = None,
             tile_format: Annotated[
@@ -132,12 +125,10 @@ class XarrayTilerFactory(BaseTilerFactory):
                     description="Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
                 ),
             ] = None,
-            tile_scale: Annotated[
+            tilesize: Annotated[
                 int,
-                Query(
-                    gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
-                ),
-            ] = 1,
+                Query(gt=0, description="Tilesize in pixels. Default to 256."),
+            ] = 256,
             minzoom: Annotated[
                 Optional[int],
                 Query(description="Overwrite default minzoom."),
@@ -167,8 +158,10 @@ class XarrayTilerFactory(BaseTilerFactory):
                 tilejson_url = self.url_for(
                     request, "tilejson", tileMatrixSetId=tileMatrixSetId
                 )
-                if request.query_params._list:
-                    tilejson_url += f"?{urlencode(request.query_params._list)}"
+                qs = list(request.query_params._list)
+                if "tilesize" not in request.query_params:
+                    qs.append(("tilesize", tilesize))
+                tilejson_url += f"?{urlencode(qs)}"
 
                 tms = self.supported_tms.get(tileMatrixSetId)
                 return titiler_templates.TemplateResponse(

--- a/src/titiler/multidim/map-form.html
+++ b/src/titiler/multidim/map-form.html
@@ -267,12 +267,6 @@
                     return typeof str === 'string' && str.length > 0;
                 }
 
-                function isStringInteger(str) {
-                    if (!str.trim()) return false;  // Check for empty strings after trimming white space
-                    const num = parseFloat(str);
-                    return !isNaN(num) && Number.isInteger(num) && String(num) === str;
-                }
-
                 document.getElementById("get-histogram-btn").addEventListener("click", function() {
                     const loadingIcon = document.getElementById('loading-icon-histogram');
                     loadingIcon.style.display = 'inline-block';
@@ -352,9 +346,6 @@
                         }
                         if (isNonEmptyString(groupValue)) {
                             href += `&group=${groupValue}`;
-                        }
-                        if (isStringInteger(groupValue)) {
-                            href += `&multiscale=true`;
                         }
                         window.location.href = href;
                     }

--- a/src/titiler/multidim/map-form.html
+++ b/src/titiler/multidim/map-form.html
@@ -337,7 +337,7 @@
                     var colormapValue = document.getElementById("colormap-dropdown").value;
                     if (urlValue) {
                         // Redirect to the map URL with the input value as a parameter
-                        var href = `map?url=${encodeURIComponent(urlValue)}&variable=${encodeURIComponent(variableValue)}&maxzoom=18`;
+                        var href = `map.html?url=${encodeURIComponent(urlValue)}&variable=${encodeURIComponent(variableValue)}&maxzoom=18`;
                         if (rescaleValue) {
                             href += `&rescale=${encodeURIComponent(rescaleValue)}`;
                         }

--- a/src/titiler/multidim/reader.py
+++ b/src/titiler/multidim/reader.py
@@ -205,37 +205,30 @@ class XarrayReader(Reader):
     """Custom XarrayReader with redis cache"""
 
     def __attrs_post_init__(self):
-        """Set bounds and CRS."""
-        self.opener = guess_opener
-        ds = None
-        # Generate cache key and attempt to fetch the dataset from cache
-        cache_key = f"{self.src_path}_group:{self.group}_time:{self.decode_times}"
+        """Configure the cached opener before the parent reads the dataset."""
+        self.opener_options = _inject_settings(
+            self.opener_options, api_settings, "authorize_virtual_chunk_access"
+        )
+        self.opener = self._open_cached
+        super().__attrs_post_init__()
+
+    def _open_cached(self, src_path: str, **kwargs: Any) -> xr.Dataset:
+        """Open a dataset, reusing its Redis cache entry when enabled."""
+        cache_key = (
+            f"{src_path}_group:{kwargs.get('group')}_time:{kwargs.get('decode_times')}"
+        )
 
         if api_settings.enable_cache:
             data_bytes = cache_client.get(cache_key)
             if data_bytes:
-                print(f"Found dataset in Cache {cache_key}")
-                ds = pickle.loads(data_bytes)
+                return pickle.loads(data_bytes)
 
-        self.opener_options = _inject_settings(
-            self.opener_options, api_settings, "authorize_virtual_chunk_access"
-        )
+        ds = guess_opener(src_path, **kwargs)
 
-        self.ds = ds or self.opener(
-            self.src_path,
-            group=self.group,
-            decode_times=self.decode_times,
-            **self.opener_options,
-        )
+        if api_settings.enable_cache:
+            cache_client.set(cache_key, pickle.dumps(ds), ex=300)
 
-        if not ds and api_settings.enable_cache:
-            # Serialize the dataset to bytes using pickle
-            cache_key = f"{self.src_path}_group:{self.group}_time:{self.decode_times}"
-            data_bytes = pickle.dumps(self.ds)
-            print(f"Adding dataset in Cache: {cache_key}")
-            cache_client.set(cache_key, data_bytes, ex=300)
-
-        super().__attrs_post_init__()
+        return ds
 
     @classmethod
     def list_variables(

--- a/tests/fixtures/responses/icechunk_native_tilejson.json
+++ b/tests/fixtures/responses/icechunk_native_tilejson.json
@@ -1,12 +1,29 @@
 {
-  "tilejson": "3.0.0",
-  "version": "1.0.0",
-  "scheme": "xyz",
-  "tiles": [
-    "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=tests%2Ffixtures%2Ficechunk_native&variable=CDD0&decode_times=false&sel=time%3D0"
-  ],
-  "minzoom": 0,
-  "maxzoom": 0,
-  "bounds": [-180.0, -90.0, 180.0, 90.0],
-  "center": [0.0, 0.0, 0]
+    "tilejson": "3.0.0",
+    "version": "1.0.0",
+    "scheme": "xyz",
+    "tiles": [
+        "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}?url=tests%2Ffixtures%2Ficechunk_native&variable=CDD0&decode_times=false&sel=time%3D0&tilesize=512"
+    ],
+    "minzoom": 0,
+    "maxzoom": 0,
+    "bounds": [
+        -180.0,
+        -90.0,
+        180.0,
+        90.0
+    ],
+    "center": [
+        0.0,
+        0.0,
+        0
+    ],
+    "raster_layers": {},
+    "band_descriptions": [
+        [
+            "b1",
+            "0"
+        ]
+    ],
+    "data_type": "float64"
 }

--- a/tests/fixtures/responses/icechunk_virtual_accessible_tilejson.json
+++ b/tests/fixtures/responses/icechunk_virtual_accessible_tilejson.json
@@ -1,21 +1,29 @@
 {
-  "tilejson": "3.0.0",
-  "version": "1.0.0",
-  "scheme": "xyz",
-  "tiles": [
-    "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=tests%2Ffixtures%2Ficechunk_virtual_accessible&variable=LWdown&decode_times=false&sel=time%3D1.0"
-  ],
-  "minzoom": 1,
-  "maxzoom": 7,
-  "bounds": [
-    -168.9999951170962,
-    7.000000114825381,
-    -51.99999725350927,
-    71.99999511680303
-  ],
-  "center": [
-    -110.49999618530273,
-    39.49999761581421,
-    1
-  ]
+    "tilejson": "3.0.0",
+    "version": "1.0.0",
+    "scheme": "xyz",
+    "tiles": [
+        "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}?url=tests%2Ffixtures%2Ficechunk_virtual_accessible&variable=LWdown&decode_times=false&sel=time%3D1.0&tilesize=512"
+    ],
+    "minzoom": 1,
+    "maxzoom": 7,
+    "bounds": [
+        -168.9999951170962,
+        7.000000114825381,
+        -51.99999725350927,
+        71.99999511680303
+    ],
+    "center": [
+        -110.49999618530273,
+        39.49999761581421,
+        1
+    ],
+    "raster_layers": {},
+    "band_descriptions": [
+        [
+            "b1",
+            "1.0"
+        ]
+    ],
+    "data_type": "float64"
 }

--- a/tests/fixtures/responses/pyramid_zarr_tilejson.json
+++ b/tests/fixtures/responses/pyramid_zarr_tilejson.json
@@ -1,12 +1,29 @@
 {
-  "tilejson": "3.0.0",
-  "version": "1.0.0",
-  "scheme": "xyz",
-  "tiles": [
-    "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=tests%2Ffixtures%2Fpyramid.zarr&variable=value&decode_times=false&group=2&sel=time%3D0"
-  ],
-  "minzoom": 0,
-  "maxzoom": 0,
-  "bounds": [-180.0, -90.0, 180.0, 90.0],
-  "center": [0.0, 0.0, 0]
+    "tilejson": "3.0.0",
+    "version": "1.0.0",
+    "scheme": "xyz",
+    "tiles": [
+        "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}?url=tests%2Ffixtures%2Fpyramid.zarr&variable=value&decode_times=false&group=2&sel=time%3D0&tilesize=512"
+    ],
+    "minzoom": 0,
+    "maxzoom": 0,
+    "bounds": [
+        -180.0,
+        -90.0,
+        180.0,
+        90.0
+    ],
+    "center": [
+        0.0,
+        0.0,
+        0
+    ],
+    "raster_layers": {},
+    "band_descriptions": [
+        [
+            "b1",
+            "0"
+        ]
+    ],
+    "data_type": "float64"
 }

--- a/tests/fixtures/responses/testfile_nc_tilejson.json
+++ b/tests/fixtures/responses/testfile_nc_tilejson.json
@@ -1,12 +1,29 @@
 {
-  "tilejson": "3.0.0",
-  "version": "1.0.0",
-  "scheme": "xyz",
-  "tiles": [
-    "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=tests%2Ffixtures%2Ftestfile.nc&variable=data&decode_times=true&sel=time%3D2020-01-01"
-  ],
-  "minzoom": 0,
-  "maxzoom": 0,
-  "bounds": [-180.0, -90.0, 180.0, 90.0],
-  "center": [0.0, 0.0, 0]
+    "tilejson": "3.0.0",
+    "version": "1.0.0",
+    "scheme": "xyz",
+    "tiles": [
+        "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}?url=tests%2Ffixtures%2Ftestfile.nc&variable=data&decode_times=true&sel=time%3D2020-01-01&tilesize=512"
+    ],
+    "minzoom": 0,
+    "maxzoom": 0,
+    "bounds": [
+        -180.0,
+        -90.0,
+        180.0,
+        90.0
+    ],
+    "center": [
+        0.0,
+        0.0,
+        0
+    ],
+    "raster_layers": {},
+    "band_descriptions": [
+        [
+            "b1",
+            "2020-01-01T00:00:00.000000000"
+        ]
+    ],
+    "data_type": "float32"
 }

--- a/tests/fixtures/responses/unconsolidated_zarr_tilejson.json
+++ b/tests/fixtures/responses/unconsolidated_zarr_tilejson.json
@@ -1,12 +1,29 @@
 {
-  "tilejson": "3.0.0",
-  "version": "1.0.0",
-  "scheme": "xyz",
-  "tiles": [
-    "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=tests%2Ffixtures%2Funconsolidated.zarr&variable=var1&decode_times=false&sel=time%3D0"
-  ],
-  "minzoom": 0,
-  "maxzoom": 0,
-  "bounds": [-180.0, -90.0, 180.0, 90.0],
-  "center": [0.0, 0.0, 0]
+    "tilejson": "3.0.0",
+    "version": "1.0.0",
+    "scheme": "xyz",
+    "tiles": [
+        "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}?url=tests%2Ffixtures%2Funconsolidated.zarr&variable=var1&decode_times=false&sel=time%3D0&tilesize=512"
+    ],
+    "minzoom": 0,
+    "maxzoom": 0,
+    "bounds": [
+        -180.0,
+        -90.0,
+        180.0,
+        90.0
+    ],
+    "center": [
+        0.0,
+        0.0,
+        0
+    ],
+    "raster_layers": {},
+    "band_descriptions": [
+        [
+            "b1",
+            "0"
+        ]
+    ],
+    "data_type": "float64"
 }

--- a/tests/fixtures/responses/zarr_store_v2_zarr_tilejson.json
+++ b/tests/fixtures/responses/zarr_store_v2_zarr_tilejson.json
@@ -1,12 +1,29 @@
 {
-  "tilejson": "3.0.0",
-  "version": "1.0.0",
-  "scheme": "xyz",
-  "tiles": [
-    "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=tests%2Ffixtures%2Fzarr_store_v2.zarr&variable=CDD0&decode_times=false&sel=time%3D0"
-  ],
-  "minzoom": 0,
-  "maxzoom": 0,
-  "bounds": [-180.0, -90.0, 180.0, 90.0],
-  "center": [0.0, 0.0, 0]
+    "tilejson": "3.0.0",
+    "version": "1.0.0",
+    "scheme": "xyz",
+    "tiles": [
+        "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}?url=tests%2Ffixtures%2Fzarr_store_v2.zarr&variable=CDD0&decode_times=false&sel=time%3D0&tilesize=512"
+    ],
+    "minzoom": 0,
+    "maxzoom": 0,
+    "bounds": [
+        -180.0,
+        -90.0,
+        180.0,
+        90.0
+    ],
+    "center": [
+        0.0,
+        0.0,
+        0
+    ],
+    "raster_layers": {},
+    "band_descriptions": [
+        [
+            "b1",
+            "0"
+        ]
+    ],
+    "data_type": "float64"
 }

--- a/tests/fixtures/responses/zarr_store_v3_zarr_tilejson.json
+++ b/tests/fixtures/responses/zarr_store_v3_zarr_tilejson.json
@@ -1,12 +1,29 @@
 {
-  "tilejson": "3.0.0",
-  "version": "1.0.0",
-  "scheme": "xyz",
-  "tiles": [
-    "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=tests%2Ffixtures%2Fzarr_store_v3.zarr&variable=CDD0&decode_times=false&sel=time%3D0"
-  ],
-  "minzoom": 0,
-  "maxzoom": 0,
-  "bounds": [-180.0, -90.0, 180.0, 90.0],
-  "center": [0.0, 0.0, 0]
+    "tilejson": "3.0.0",
+    "version": "1.0.0",
+    "scheme": "xyz",
+    "tiles": [
+        "http://testserver/tiles/WebMercatorQuad/{z}/{x}/{y}?url=tests%2Ffixtures%2Fzarr_store_v3.zarr&variable=CDD0&decode_times=false&sel=time%3D0&tilesize=512"
+    ],
+    "minzoom": 0,
+    "maxzoom": 0,
+    "bounds": [
+        -180.0,
+        -90.0,
+        180.0,
+        90.0
+    ],
+    "center": [
+        0.0,
+        0.0,
+        0
+    ],
+    "raster_layers": {},
+    "band_descriptions": [
+        [
+            "b1",
+            "0"
+        ]
+    ],
+    "data_type": "float64"
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 import json
 import os
+from urllib.parse import urlencode
 
 import pytest
 from helpers import find_string_in_stream
@@ -223,6 +224,10 @@ def test_map_with_params(store_params, app):
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert find_string_in_stream(response, '<div id="map"></div>')
     assert find_string_in_stream(response, "tilesize=256")
+    point_query = urlencode({"url": store_path, "variable": variable})
+    assert find_string_in_stream(
+        response, f"point/{{lon}},{{lat}}?{point_query}`.replace"
+    )
 
 
 def test_tilejson_forwards_tilesize(app):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -222,10 +222,20 @@ def test_map_with_params(store_params, app):
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert find_string_in_stream(response, '<div id="map"></div>')
+    assert find_string_in_stream(response, "tilesize=256")
+
+
+def test_tilejson_forwards_tilesize(app):
+    params = {**store_params["zarr_store_v2"]["params"], "tilesize": 256}
+    response = app.get("/WebMercatorQuad/tilejson.json", params=params)
+
+    assert response.status_code == 200
+    assert "@" not in response.json()["tiles"][0]
+    assert "tilesize=256" in response.json()["tiles"][0]
 
 
 def test_sel_nearest_netcdf(app):
     params = store_params["netcdf_store"]["params"].copy()
-    params.update({"sel": "time=2020-01-06", "sel_method": "nearest"})
+    params["sel"] = "time=nearest::2020-01-06"
     response = app.get("/info", params=params)
     assert response.status_code == 200

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -207,7 +207,7 @@ def test_histogram_error(store_params, app):
 
 
 def test_map_without_params(app):
-    response = app.get("/WebMercatorQuad/map")
+    response = app.get("/WebMercatorQuad/map.html")
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert find_string_in_stream(response, "Step 1: Enter the URL of your Zarr store")
@@ -218,7 +218,7 @@ def test_map_with_params(store_params, app):
     store_path = store_params["params"]["url"]
     variable = store_params["variables"][0]
     response = app.get(
-        "/WebMercatorQuad/map", params={"url": store_path, "variable": variable}
+        "/WebMercatorQuad/map.html", params={"url": store_path, "variable": variable}
     )
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
@@ -227,6 +227,16 @@ def test_map_with_params(store_params, app):
     point_query = urlencode({"url": store_path, "variable": variable})
     assert find_string_in_stream(
         response, f"point/{{lon}},{{lat}}?{point_query}`.replace"
+    )
+
+
+def test_legacy_map_redirect(app):
+    params = {"url": test_zarr_store_v2, "variable": "CDD0"}
+    response = app.get("/WebMercatorQuad/map", params=params, follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == (
+        f"/WebMercatorQuad/map.html?{urlencode(params)}"
     )
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,29 @@
+"""Reader tests."""
+
+import numpy as np
+import xarray as xr
+from fakeredis import FakeRedis
+
+
+def test_reader_reuses_cached_dataset(monkeypatch):
+    """Reuse a cached dataset instead of reopening it in the parent reader."""
+    import titiler.multidim.reader as reader
+
+    opened = 0
+
+    def opener(*args, **kwargs):
+        nonlocal opened
+        opened += 1
+        return xr.Dataset(
+            {"data": (("y", "x"), np.ones((2, 2)))},
+            coords={"x": [0, 1], "y": [1, 0]},
+        ).rio.write_crs("EPSG:4326")
+
+    monkeypatch.setattr(reader, "cache_client", FakeRedis())
+    monkeypatch.setattr(reader.api_settings, "enable_cache", True)
+    monkeypatch.setattr(reader, "guess_opener", opener)
+
+    reader.XarrayReader("cache.zarr", "data")
+    reader.XarrayReader("cache.zarr", "data")
+
+    assert opened == 1

--- a/uv.lock
+++ b/uv.lock
@@ -769,6 +769,74 @@ wheels = [
 ]
 
 [[package]]
+name = "cramjam"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/12/34bf6e840a79130dfd0da7badfb6f7810b8fcfd60e75b0539372667b41b6/cramjam-2.11.0.tar.gz", hash = "sha256:5c82500ed91605c2d9781380b378397012e25127e89d64f460fea6aeac4389b4", size = 99100, upload-time = "2025-07-27T21:25:07.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/0d/7c84c913a5fae85b773a9dcf8874390f9d68ba0fcc6630efa7ff1541b950/cramjam-2.11.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:dba5c14b8b4f73ea1e65720f5a3fe4280c1d27761238378be8274135c60bbc6e", size = 3553368, upload-time = "2025-07-27T21:22:27.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/cc/4f6d185d8a744776f53035e72831ff8eefc2354f46ab836f4bd3c4f6c138/cramjam-2.11.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:11eb40722b3fcf3e6890fba46c711bf60f8dc26360a24876c85e52d76c33b25b", size = 1860014, upload-time = "2025-07-27T21:22:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a8/626c76263085c6d5ded0e71823b411e9522bfc93ba6cc59855a5869296e7/cramjam-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aeb26e2898994b6e8319f19a4d37c481512acdcc6d30e1b5ecc9d8ec57e835cb", size = 1693512, upload-time = "2025-07-27T21:22:30.999Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/52/0851a16a62447532e30ba95a80e638926fdea869a34b4b5b9d0a020083ba/cramjam-2.11.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4f8d82081ed7d8fe52c982bd1f06e4c7631a73fe1fb6d4b3b3f2404f87dc40fe", size = 2025285, upload-time = "2025-07-27T21:22:32.954Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/122e444f59dbc216451d8e3d8282c9665dc79eaf822f5f1470066be1b695/cramjam-2.11.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:092a3ec26e0a679305018380e4f652eae1b6dfe3fc3b154ee76aa6b92221a17c", size = 1761327, upload-time = "2025-07-27T21:22:34.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/bc/3a0189aef1af2b29632c039c19a7a1b752bc21a4053582a5464183a0ad3d/cramjam-2.11.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:529d6d667c65fd105d10bd83d1cd3f9869f8fd6c66efac9415c1812281196a92", size = 1854075, upload-time = "2025-07-27T21:22:36.157Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/80/8a6343b13778ce52d94bb8d5365a30c3aa951276b1857201fe79d7e2ad25/cramjam-2.11.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:555eb9c90c450e0f76e27d9ff064e64a8b8c6478ab1a5594c91b7bc5c82fd9f0", size = 2032710, upload-time = "2025-07-27T21:22:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6b/cd1778a207c29eda10791e3dfa018b588001928086e179fc71254793c625/cramjam-2.11.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5edf4c9e32493035b514cf2ba0c969d81ccb31de63bd05490cc8bfe3b431674e", size = 2068353, upload-time = "2025-07-27T21:22:39.615Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f0/5c2a5cd5711032f3b191ca50cb786c17689b4a9255f9f768866e6c9f04d9/cramjam-2.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fa2fe41f48c4d58d923803383b0737f048918b5a0d10390de9628bb6272b107", size = 1978104, upload-time = "2025-07-27T21:22:41.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8b/b363a5fb2c3347504fe9a64f8d0f1e276844f0e532aa7162c061cd1ffee4/cramjam-2.11.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9ca14cf1cabdb0b77d606db1bb9e9ca593b1dbd421fcaf251ec9a5431ec449f3", size = 2030779, upload-time = "2025-07-27T21:22:42.969Z" },
+    { url = "https://files.pythonhosted.org/packages/78/7b/d83dad46adb6c988a74361f81ad9c5c22642be53ad88616a19baedd06243/cramjam-2.11.0-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:309e95bf898829476bccf4fd2c358ec00e7ff73a12f95a3cdeeba4bb1d3683d5", size = 2155297, upload-time = "2025-07-27T21:22:44.6Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/60d9be4cb33d8740a4aa94c7513f2ef3c4eba4fd13536f086facbafade71/cramjam-2.11.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:86dca35d2f15ef22922411496c220f3c9e315d5512f316fe417461971cc1648d", size = 2169255, upload-time = "2025-07-27T21:22:46.534Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b0/4a595f01a243aec8ad272b160b161c44351190c35d98d7787919d962e9e5/cramjam-2.11.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:193c6488bd2f514cbc0bef5c18fad61a5f9c8d059dd56edf773b3b37f0e85496", size = 2155651, upload-time = "2025-07-27T21:22:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/38/47/7776659aaa677046b77f527106e53ddd47373416d8fcdb1e1a881ec5dc06/cramjam-2.11.0-cp312-cp312-win32.whl", hash = "sha256:514e2c008a8b4fa823122ca3ecab896eac41d9aa0f5fc881bd6264486c204e32", size = 1603568, upload-time = "2025-07-27T21:22:50.084Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b1/d53002729cfd94c5844ddfaf1233c86d29f2dbfc1b764a6562c41c044199/cramjam-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:53fed080476d5f6ad7505883ec5d1ec28ba36c2273db3b3e92d7224fe5e463db", size = 1709287, upload-time = "2025-07-27T21:22:51.534Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/8b/406c5dc0f8e82385519d8c299c40fd6a56d97eca3fcd6f5da8dad48de75b/cramjam-2.11.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2c289729cc1c04e88bafa48b51082fb462b0a57dbc96494eab2be9b14dca62af", size = 3553330, upload-time = "2025-07-27T21:22:53.124Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ad/4186884083d6e4125b285903e17841827ab0d6d0cffc86216d27ed91e91d/cramjam-2.11.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:045201ee17147e36cf43d8ae2fa4b4836944ac672df5874579b81cf6d40f1a1f", size = 1859756, upload-time = "2025-07-27T21:22:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/54/01/91b485cf76a7efef638151e8a7d35784dae2c4ff221b1aec2c083e4b106d/cramjam-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:619cd195d74c9e1d2a3ad78d63451d35379c84bd851aec552811e30842e1c67a", size = 1693609, upload-time = "2025-07-27T21:22:56.331Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/84/d0c80d279b2976870fc7d10f15dcb90a3c10c06566c6964b37c152694974/cramjam-2.11.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6eb3ae5ab72edb2ed68bdc0f5710f0a6cad7fd778a610ec2c31ee15e32d3921e", size = 2024912, upload-time = "2025-07-27T21:22:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/70/88f2a5cb904281ed5d3c111b8f7d5366639817a5470f059bcd26833fc870/cramjam-2.11.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df7da3f4b19e3078f9635f132d31b0a8196accb2576e3213ddd7a77f93317c20", size = 1760715, upload-time = "2025-07-27T21:22:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/cf5b02081132537d28964fb385fcef9ed9f8a017dd7d8c59d317e53ba50d/cramjam-2.11.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:57286b289cd557ac76c24479d8ecfb6c3d5b854cce54ccc7671f9a2f5e2a2708", size = 1853782, upload-time = "2025-07-27T21:23:01.07Z" },
+    { url = "https://files.pythonhosted.org/packages/57/27/63525087ed40a53d1867021b9c4858b80cc86274ffe7225deed067d88d92/cramjam-2.11.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:28952fbbf8b32c0cb7fa4be9bcccfca734bf0d0989f4b509dc7f2f70ba79ae06", size = 2032354, upload-time = "2025-07-27T21:23:03.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ef/dbba082c6ebfb6410da4dd39a64e654d7194fcfd4567f85991a83fa4ec32/cramjam-2.11.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78ed2e4099812a438b545dfbca1928ec825e743cd253bc820372d6ef8c3adff4", size = 2068007, upload-time = "2025-07-27T21:23:04.526Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ce/d902b9358a46a086938feae83b2251720e030f06e46006f4c1fc0ac9da20/cramjam-2.11.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d9aecd5c3845d415bd6c9957c93de8d93097e269137c2ecb0e5a5256374bdc8", size = 1977485, upload-time = "2025-07-27T21:23:06.058Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/03/982f54553244b0afcbdb2ad2065d460f0ab05a72a96896a969a1ca136a1e/cramjam-2.11.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:362fcf4d6f5e1242a4540812455f5a594949190f6fbc04f2ffbfd7ae0266d788", size = 2030447, upload-time = "2025-07-27T21:23:07.679Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5f/748e54cdb665ec098ec519e23caacc65fc5ae58718183b071e33fc1c45b4/cramjam-2.11.0-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:13240b3dea41b1174456cb9426843b085dc1a2bdcecd9ee2d8f65ac5703374b0", size = 2154949, upload-time = "2025-07-27T21:23:09.366Z" },
+    { url = "https://files.pythonhosted.org/packages/69/81/c4e6cb06ed69db0dc81f9a8b1dc74995ebd4351e7a1877143f7031ff2700/cramjam-2.11.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:c54eed83726269594b9086d827decc7d2015696e31b99bf9b69b12d9063584fe", size = 2168925, upload-time = "2025-07-27T21:23:10.976Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5b/966365523ce8290a08e163e3b489626c5adacdff2b3da9da1b0823dfb14e/cramjam-2.11.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f8195006fdd0fc0a85b19df3d64a3ef8a240e483ae1dfc7ac6a4316019eb5df2", size = 2154950, upload-time = "2025-07-27T21:23:12.514Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/7d/7f8eb5c534b72b32c6eb79d74585bfee44a9a5647a14040bb65c31c2572d/cramjam-2.11.0-cp313-cp313-win32.whl", hash = "sha256:ccf30e3fe6d770a803dcdf3bb863fa44ba5dc2664d4610ba2746a3c73599f2e4", size = 1603199, upload-time = "2025-07-27T21:23:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/37/05/47b5e0bf7c41a3b1cdd3b7c2147f880c93226a6bef1f5d85183040cbdece/cramjam-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:ee36348a204f0a68b03400f4736224e9f61d1c6a1582d7f875c1ca56f0254268", size = 1708924, upload-time = "2025-07-27T21:23:16.332Z" },
+    { url = "https://files.pythonhosted.org/packages/de/07/a1051cdbbe6d723df16d756b97f09da7c1adb69e29695c58f0392bc12515/cramjam-2.11.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7ba5e38c9fbd06f086f4a5a64a1a5b7b417cd3f8fc07a20e5c03651f72f36100", size = 3554141, upload-time = "2025-07-27T21:23:17.938Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/58487d2e16ef3d04f51a7c7f0e69823e806744b4c21101e89da4873074bc/cramjam-2.11.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8adeee57b41fe08e4520698a4b0bd3cc76dbd81f99424b806d70a5256a391d3", size = 1860353, upload-time = "2025-07-27T21:23:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b4/67f6254d166ffbcc9d5fa1b56876eaa920c32ebc8e9d3d525b27296b693b/cramjam-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b96a74fa03a636c8a7d76f700d50e9a8bc17a516d6a72d28711225d641e30968", size = 1693832, upload-time = "2025-07-27T21:23:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/55/a3/4e0b31c0d454ae70c04684ed7c13d3c67b4c31790c278c1e788cb804fa4a/cramjam-2.11.0-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c3811a56fa32e00b377ef79121c0193311fd7501f0fb378f254c7f083cc1fbe0", size = 2027080, upload-time = "2025-07-27T21:23:23.303Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c7/5e8eed361d1d3b8be14f38a54852c5370cc0ceb2c2d543b8ba590c34f080/cramjam-2.11.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5d927e87461f8a0d448e4ab5eb2bca9f31ca5d8ea86d70c6f470bb5bc666d7e", size = 1761543, upload-time = "2025-07-27T21:23:24.991Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0c/06b7f8b0ce9fde89470505116a01fc0b6cb92d406c4fb1e46f168b5d3fa5/cramjam-2.11.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f1f5c450121430fd89cb5767e0a9728ecc65997768fd4027d069cb0368af62f9", size = 1854636, upload-time = "2025-07-27T21:23:26.987Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c6/6ebc02c9d5acdf4e5f2b1ec6e1252bd5feee25762246798ae823b3347457/cramjam-2.11.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:724aa7490be50235d97f07e2ca10067927c5d7f336b786ddbc868470e822aa25", size = 2032715, upload-time = "2025-07-27T21:23:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/77/a122971c23f5ca4b53e4322c647ac7554626c95978f92d19419315dddd05/cramjam-2.11.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54c4637122e7cfd7aac5c1d3d4c02364f446d6923ea34cf9d0e8816d6e7a4936", size = 2069039, upload-time = "2025-07-27T21:23:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f6121b90b86b9093c066889274d26a1de3f29969d45c2ed1ecbe2033cb78/cramjam-2.11.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17eb39b1696179fb471eea2de958fa21f40a2cd8bf6b40d428312d5541e19dc4", size = 1979566, upload-time = "2025-07-27T21:23:32.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/f95bc57fd7f4166ce6da816cfa917fb7df4bb80e669eb459d85586498414/cramjam-2.11.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:36aa5a798aa34e11813a80425a30d8e052d8de4a28f27bfc0368cfc454d1b403", size = 2030905, upload-time = "2025-07-27T21:23:33.696Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/52/e429de4e8bc86ee65e090dae0f87f45abd271742c63fb2d03c522ffde28a/cramjam-2.11.0-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:449fca52774dc0199545fbf11f5128933e5a6833946707885cf7be8018017839", size = 2155592, upload-time = "2025-07-27T21:23:35.375Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6c/65a7a0207787ad39ad804af4da7f06a60149de19481d73d270b540657234/cramjam-2.11.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:d87d37b3d476f4f7623c56a232045d25bd9b988314702ea01bd9b4a94948a778", size = 2170839, upload-time = "2025-07-27T21:23:37.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c5/5c5db505ba692bc844246b066e23901d5905a32baf2f33719c620e65887f/cramjam-2.11.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:26cb45c47d71982d76282e303931c6dd4baee1753e5d48f9a89b3a63e690b3a3", size = 2157236, upload-time = "2025-07-27T21:23:38.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/22/88e6693e60afe98901e5bbe91b8dea193e3aa7f42e2770f9c3339f5c1065/cramjam-2.11.0-cp314-cp314-win32.whl", hash = "sha256:4efe919d443c2fd112fe25fe636a52f9628250c9a50d9bddb0488d8a6c09acc6", size = 1604136, upload-time = "2025-07-27T21:23:40.56Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f8/01618801cd59ccedcc99f0f96d20be67d8cfc3497da9ccaaad6b481781dd/cramjam-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ccec3524ea41b9abd5600e3e27001fd774199dbb4f7b9cb248fcee37d4bda84c", size = 1710272, upload-time = "2025-07-27T21:23:42.236Z" },
+    { url = "https://files.pythonhosted.org/packages/40/81/6cdb3ed222d13ae86bda77aafe8d50566e81a1169d49ed195b6263610704/cramjam-2.11.0-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:966ac9358b23d21ecd895c418c048e806fd254e46d09b1ff0cdad2eba195ea3e", size = 3559671, upload-time = "2025-07-27T21:23:44.504Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/43/52b7e54fe5ba1ef0270d9fdc43dabd7971f70ea2d7179be918c997820247/cramjam-2.11.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:387f09d647a0d38dcb4539f8a14281f8eb6bb1d3e023471eb18a5974b2121c86", size = 1867876, upload-time = "2025-07-27T21:23:46.987Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/28/30d5b8d10acd30db3193bc562a313bff722888eaa45cfe32aa09389f2b24/cramjam-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:665b0d8fbbb1a7f300265b43926457ec78385200133e41fef19d85790fc1e800", size = 1695562, upload-time = "2025-07-27T21:23:48.644Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/86/ec806f986e01b896a650655024ea52a13e25c3ac8a3a382f493089483cdc/cramjam-2.11.0-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ca905387c7a371531b9622d93471be4d745ef715f2890c3702479cd4fc85aa51", size = 2025056, upload-time = "2025-07-27T21:23:50.404Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/c2c17586b90848d29d63181f7d14b8bd3a7d00975ad46e3edf2af8af7e1f/cramjam-2.11.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c1aa56aef2c8af55a21ed39040a94a12b53fb23beea290f94d19a76027e2ffb", size = 1764084, upload-time = "2025-07-27T21:23:52.265Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/68bc334fadb434a61df10071dc8606702aa4f5b6cdb2df62474fc21d2845/cramjam-2.11.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e5db59c1cdfaa2ab85cc988e602d6919495f735ca8a5fd7603608eb1e23c26d5", size = 1854859, upload-time = "2025-07-27T21:23:54.085Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4e/b48e67835b5811ec5e9cb2e2bcba9c3fd76dab3e732569fe801b542c6ca9/cramjam-2.11.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b1f893014f00fe5e89a660a032e813bf9f6d91de74cd1490cdb13b2b59d0c9a3", size = 2035970, upload-time = "2025-07-27T21:23:55.758Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/70/d2ac33d572b4d90f7f0f2c8a1d60fb48f06b128fdc2c05f9b49891bb0279/cramjam-2.11.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c26a1eb487947010f5de24943bd7c422dad955b2b0f8650762539778c380ca89", size = 2069320, upload-time = "2025-07-27T21:23:57.494Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4c/85cec77af4a74308ba5fca8e296c4e2f80ec465c537afc7ab1e0ca2f9a00/cramjam-2.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d5c8bfb438d94e7b892d1426da5fc4b4a5370cc360df9b8d9d77c33b896c37e", size = 1982668, upload-time = "2025-07-27T21:23:59.126Z" },
+    { url = "https://files.pythonhosted.org/packages/55/45/938546d1629e008cc3138df7c424ef892719b1796ff408a2ab8550032e5e/cramjam-2.11.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:cb1fb8c9337ab0da25a01c05d69a0463209c347f16512ac43be5986f3d1ebaf4", size = 2034028, upload-time = "2025-07-27T21:24:00.865Z" },
+    { url = "https://files.pythonhosted.org/packages/01/76/b5a53e20505555f1640e66dcf70394bcf51a1a3a072aa18ea35135a0f9ed/cramjam-2.11.0-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:1f6449f6de52dde3e2f1038284910c8765a397a25e2d05083870f3f5e7fc682c", size = 2155513, upload-time = "2025-07-27T21:24:02.92Z" },
+    { url = "https://files.pythonhosted.org/packages/84/12/8d3f6ceefae81bbe45a347fdfa2219d9f3ac75ebc304f92cd5fcb4fbddc5/cramjam-2.11.0-cp314-cp314t-musllinux_1_1_i686.whl", hash = "sha256:382dec4f996be48ed9c6958d4e30c2b89435d7c2c4dbf32480b3b8886293dd65", size = 2170035, upload-time = "2025-07-27T21:24:04.558Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/85/3be6f0a1398f976070672be64f61895f8839857618a2d8cc0d3ab529d3dc/cramjam-2.11.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:d388bd5723732c3afe1dd1d181e4213cc4e1be210b080572e7d5749f6e955656", size = 2160229, upload-time = "2025-07-27T21:24:06.729Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/66cfc3635511b20014bbb3f2ecf0095efb3049e9e96a4a9e478e4f3d7b78/cramjam-2.11.0-cp314-cp314t-win32.whl", hash = "sha256:0a70ff17f8e1d13f322df616505550f0f4c39eda62290acb56f069d4857037c8", size = 1610267, upload-time = "2025-07-27T21:24:08.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c6/c71e82e041c95ffe6a92ac707785500aa2a515a4339c2c7dd67e3c449249/cramjam-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:028400d699442d40dbda02f74158c73d05cb76587a12490d0bfedd958fd49188", size = 1713108, upload-time = "2025-07-27T21:24:10.147Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -879,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -888,9 +956,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -1170,19 +1238,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
 name = "httpcore2"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1193,21 +1248,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/7e/8ab39aab1d392845b6512009a9be57d24a5bd4ec7a22d02e513d0645e7a8/httpcore2-2.2.0.tar.gz", hash = "sha256:10e0e142f1ecc1c1cb2a9ebbce82e57f16169f61d163ea336abf36799e89294b", size = 63533, upload-time = "2026-05-17T05:29:55.836Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/22/64de17e7956e8c002f7558ed667d924c2a288344aeff4bd8ff5dc5fdb70b/httpcore2-2.2.0-py3-none-any.whl", hash = "sha256:ce859f268bf8d34fa2d7753e09e4dd5194f557e1b3038439b68a89b2999572fa", size = 79288, upload-time = "2026-05-17T05:29:52.56Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -3070,24 +3110,24 @@ wheels = [
 
 [[package]]
 name = "rio-tiler"
-version = "7.9.5"
+version = "9.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "cachetools" },
     { name = "color-operations" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "morecantile" },
     { name = "numexpr" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "pystac" },
     { name = "rasterio" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/0f/ac3177f82b14087efb6f022cce41ec833883ab86933f84dfe0477e1cd46b/rio_tiler-7.9.5.tar.gz", hash = "sha256:a94c651cfd3ff7bce0474627080ddeb01ce0e45800a397a6b10c1a5355821b1d", size = 176205, upload-time = "2026-03-24T17:43:48.407Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/ae/5721191854ffd8410f39ac4380818975337b84e01753b3b5cc2b4c38d0c8/rio_tiler-9.4.2.tar.gz", hash = "sha256:0c0fd217b68d17cb71c79b6bf3350c36c2927096fff7352e7c06f1ce5e57d528", size = 212352, upload-time = "2026-07-20T16:20:33.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/3e/c49bd1ddf571b89d39a96ec7d63ecd8818f4aef33b00f479231260afe43a/rio_tiler-7.9.5-py3-none-any.whl", hash = "sha256:4000894b49093bc2f32deea7d0565f1bf362c39faade05e1737f93ab9e299383", size = 270499, upload-time = "2026-03-24T17:43:49.717Z" },
+    { url = "https://files.pythonhosted.org/packages/02/26/e5d5a1eaa4b48d17fe8780ba215a8cd5348b4cef3e081bf4647cfbb63bc2/rio_tiler-9.4.2-py3-none-any.whl", hash = "sha256:2f9814072a6483209bcb808fd0de7e7050e803d6186f5625d5a3cc33dc32d873", size = 316063, upload-time = "2026-07-20T16:20:31.733Z" },
 ]
 
 [[package]]
@@ -3256,8 +3296,21 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette-cramjam"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cramjam" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/83/79d2060127c8158849f375a21adf4116639d4829b84bbca598514a2ca871/starlette_cramjam-0.7.0.tar.gz", hash = "sha256:38a70bea50d2fce91eb43acbddd544c1c7d4b5de4b26a482472d7dc142024edd", size = 7614, upload-time = "2026-04-27T08:39:30.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/1f/7611cb364b60e69f50afd6b5a5dc336c24450d6a1ed87431d944700b834c/starlette_cramjam-0.7.0-py3-none-any.whl", hash = "sha256:a0754bd582aa5cdd7d2e9982ea0bd9c78521583099590971e9cf0482fe26b8a4", size = 8060, upload-time = "2026-04-27T08:39:28.676Z" },
+]
+
+[[package]]
 name = "titiler-core"
-version = "0.25.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
@@ -3269,11 +3322,11 @@ dependencies = [
     { name = "rasterio" },
     { name = "rio-tiler" },
     { name = "simplejson" },
-    { name = "typing-extensions" },
+    { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/6d/f4a00eff755081466eba4dfe406bdca084e9bb6c62616f67e77146edae05/titiler_core-0.25.0.tar.gz", hash = "sha256:a03a169e77d0c4804a0d3c7e8259d6640386f19c8ef60232dfb07069ae10aecb", size = 69584, upload-time = "2025-11-07T16:14:23.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/ee/0b5fa5ace09943103db953115a994295e4cb3da26a3bfa53319b654a6150/titiler_core-2.2.1.tar.gz", hash = "sha256:61bd6fe35e766795ec9acc2ad58351426802e8ee6d06925724d3084fc20a53ed", size = 70324, upload-time = "2026-07-29T16:03:22.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9e/fcc8da9e7879facb2b53c33c741422523d37d0fcf090c5851fb455f26c43/titiler_core-0.25.0-py3-none-any.whl", hash = "sha256:134179c2a5599cd583edc7295e549422fc3ea16e3d84b82249c75f99e95b3849", size = 88057, upload-time = "2025-11-07T16:14:22.464Z" },
+    { url = "https://files.pythonhosted.org/packages/93/de/6ec9fe2d24508308d57b66db7060ca24b2e9c39dd9b9d95fabc365f39302/titiler_core-2.2.1-py3-none-any.whl", hash = "sha256:82ae4511d33ff26da0097d58cb0e34b61ef4a20b91589d1586d9f24be64aadf0", size = 88825, upload-time = "2026-07-29T16:03:15.701Z" },
 ]
 
 [[package]]
@@ -3376,8 +3429,8 @@ requires-dist = [
     { name = "requests" },
     { name = "rioxarray" },
     { name = "s3fs" },
-    { name = "titiler-core", specifier = ">=0.25.0,<0.26" },
-    { name = "titiler-xarray", specifier = ">=0.25.0,<0.26" },
+    { name = "titiler-core", specifier = ">=2.2.1,<3.0" },
+    { name = "titiler-xarray", specifier = ">=2.2.1,<3.0" },
     { name = "uvicorn", marker = "extra == 'server'" },
     { name = "xarray", specifier = ">=2025.10.1" },
     { name = "zarr", specifier = ">=3.2.0" },
@@ -3415,19 +3468,21 @@ notebooks = [
 
 [[package]]
 name = "titiler-xarray"
-version = "0.25.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "httpx2" },
     { name = "obstore" },
-    { name = "rio-tiler" },
+    { name = "pydantic-settings" },
     { name = "rioxarray" },
+    { name = "starlette-cramjam" },
     { name = "titiler-core" },
     { name = "xarray" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/1a/c307ef40902e9ec44058425654e6883b44fc6ed60da7480568489d84cec5/titiler_xarray-0.25.0.tar.gz", hash = "sha256:75831236fc39d6bd9dd9458c3e48e014359344078016254cf1fc8ddf362e3919", size = 31334, upload-time = "2025-11-07T16:14:26.499Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/01/9db661a7dba346c1cff5c8d4aea5fa8270b8b9a942ae3fca92b8c1fbd2c0/titiler_xarray-2.2.1.tar.gz", hash = "sha256:f7d11a38bcc3cbe68377c93d2e28768838f6a03e7abd3ce772e45b75d6d94315", size = 32544, upload-time = "2026-07-29T16:03:25.02Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/77/dd11991dcc7b6c8411bdde746c9cac8d70d27b09a5027538c6ec8b7150fe/titiler_xarray-0.25.0-py3-none-any.whl", hash = "sha256:6c9015a65440fef177803533e3eb3d9563de932b87500a05616c3daa8b21cf3f", size = 32768, upload-time = "2025-11-07T16:14:25.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5a/f3c70d1c6e04647d5f16a032ec9441ccd30ae71edee6fe09d83bb8755601/titiler_xarray-2.2.1-py3-none-any.whl", hash = "sha256:7cc080518606478f182c05b89ac61f6b804076790294770bb3c12e69a372a6de", size = 34346, upload-time = "2026-07-29T16:03:20.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrade to titiler 2.2! And fix a few other small bugs.

## Testing

- I checked a handful of Icechunk datasets on the deployed endpoint - everything is working great!
- I also checked a plain old zarr store: s3://mur-sst/zarr-v1
- I added a smoketest script to do some actual tile requests from the deployed endpoint at the end of the deploy-dev workflow

## PR checks

- Standard CI runs automatically on each push.
- To run the CDK synth check, add the `run-cdk-checks` label to this PR.
- If you push more commits after that run completes, remove and re-add the label to run it again.
- To trigger a dev deployment, add the `deploy-dev` label.


resolves #135 
resolves #111 